### PR TITLE
Remove delete contacts sections

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -899,17 +899,6 @@ Contacts can be attached to Cards to help you keep track of who is interacting w
                 }
             }
 
-### Delete Contact [DELETE /contacts/{contactId}]
-+ Parameters 
-    + contactId (string, required) 
-    
-+ Request (application/json)
-    + Headers
-    
-            Authorization: Bearer <YOUR_ACCESS_TOKEN>
-
-+ Response 204
-
 ### Retrieve Account Cards or Gift Cards for Contact [GET /cards{?contactId}{?cardType}{?currency}]
 + Parameters 
     + contactId (string, required) 


### PR DESCRIPTION
- This feature is being deprecated for the time being. Contact management and allowing our users to keep meaningful lists of active contacts is a high priority of ours. We felt the current implementation wasn't fulfilling this requirement very well. We plan to improve it in the near future. 