### PR TITLE
Client libraries list

### DIFF
--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -1,0 +1,29 @@
+##Integrations
+Here is the list of Lightrail integrations for different technologies and languages. If you are planning to integrate with Lightrail, before embarking on development check out this list to see if we already have a client library or plugin suitable for your project.
+
+## Languages
+
+### Java
+- [Lightrail Java Client](https://github.com/Giftbit/lightrail-client-java)
+- [Lightrail Stripe Integration for Java](https://github.com/Giftbit/lightrail-stripe-java)
+
+### PHP
+
+- [Lightrail WooCommerce Plugin](https://wordpress.org/plugins/lightrail-for-woocommerce/)
+
+### Ruby
+- [Lightrail Ruby Client](https://github.com/Giftbit/lightrail-client-ruby)
+- [Lightrail Stripe Integration for Ruby](https://github.com/Giftbit/lightrail-stripe-ruby)
+
+### Typescript
+- [Lightrail Typescript Client](https://github.com/Giftbit/lightrail-client-javascript)
+
+## Third-Party Platforms
+
+### Stripe
+- [Lightrail Stripe Integration for Java](https://github.com/Giftbit/lightrail-stripe-java)
+- [Lightrail Stripe Integration for Ruby](https://github.com/Giftbit/lightrail-stripe-ruby)
+
+
+### WooCommerce
+- [Lightrail WooCommerce Plugin](https://wordpress.org/plugins/lightrail-for-woocommerce/)

--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -1,4 +1,4 @@
-##Integrations
+# Integrations
 Here is the list of Lightrail integrations for different technologies and languages. If you are planning to integrate with Lightrail, before embarking on development check out this list to see if we already have a client library or plugin suitable for your project.
 
 ## Languages

--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -1,29 +1,27 @@
-# Integrations
-Here is the list of Lightrail integrations for different technologies and languages. If you are planning to integrate with Lightrail, before embarking on development check out this list to see if we already have a client library or plugin suitable for your project.
+# Client Libraries
+Here is the list of Lightrail client libraries for different languages and technologies. If you are planning to integrate with Lightrail, before embarking on development check out this list to see if we already have a client library or plugin suitable for your project.
 
-## Languages
+## Client Libraries
 
 ### Java
 - [Lightrail Java Client](https://github.com/Giftbit/lightrail-client-java)
 - [Lightrail Stripe Integration for Java](https://github.com/Giftbit/lightrail-stripe-java)
 
 ### PHP
-
 - [Lightrail WooCommerce Plugin](https://wordpress.org/plugins/lightrail-for-woocommerce/)
 
 ### Ruby
 - [Lightrail Ruby Client](https://github.com/Giftbit/lightrail-client-ruby)
 - [Lightrail Stripe Integration for Ruby](https://github.com/Giftbit/lightrail-stripe-ruby)
 
-### Typescript
+### JavaScript/TypeScript
 - [Lightrail Typescript Client](https://github.com/Giftbit/lightrail-client-javascript)
 
-## Third-Party Platforms
+## Third-Party Integrations
 
 ### Stripe
 - [Lightrail Stripe Integration for Java](https://github.com/Giftbit/lightrail-stripe-java)
 - [Lightrail Stripe Integration for Ruby](https://github.com/Giftbit/lightrail-stripe-ruby)
-
 
 ### WooCommerce
 - [Lightrail WooCommerce Plugin](https://wordpress.org/plugins/lightrail-for-woocommerce/)


### PR DESCRIPTION
Adding a list of client libraries & integration for easy referencing by other docs. This needs to live in a separate place that's easy to reference to avoid duplication. 